### PR TITLE
Fix error with Node v5.6.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ utils.collectStream = function(source, callback) {
   });
 
   source.on('end', function() {
-    var buf = new Buffer(size, 'utf8');
+    var buf = new Buffer(size);
     var offset = 0;
 
     collection.forEach(function(data) {


### PR DESCRIPTION
If encoding is specified then the first argument must be a string.