### PR TITLE
Removing publishConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,5 @@
     "mkdirp": "3.0.1",
     "mocha": "9.2.2",
     "rimraf": "3.0.2"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
The publishConfig in package.json tied the package to the public npm registry. npmjs.org is the default registry and is also specified in the npmpublish.yml github action, so publishConfig within the package is not necessary. Additionally, publishConfig overrides the target registry specified in any other way (.npmrc, cli, github action), making it impossible to publish to test or private registries without manually modifying the package.